### PR TITLE
Potential fix for code scanning alert no. 41: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale-actions.yml
+++ b/.github/workflows/stale-actions.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/terraform-global-naming/security/code-scanning/41](https://github.com/devops-ia/terraform-global-naming/security/code-scanning/41)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the top level to apply to all jobs, or under the `stale` job). This block should grant only the minimal permissions required: write access to issues and pull requests (to comment, label, and close them) and read access to repository contents. There is no need to alter steps or secret usage.

The best minimal fix without changing existing functionality is to add a `permissions` section at the root of `.github/workflows/stale-actions.yml`, between the `on:` block and the `jobs:` block. This will apply to the single `stale` job. We will grant: `contents: read` (to safely match recommended minimal defaults) and `issues: write` and `pull-requests: write` so that the stale action can label and close issues/PRs. No imports or additional methods are needed, because this is a YAML configuration change only.

Concretely: in `.github/workflows/stale-actions.yml`, insert:

```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

after line 4–5 (after the `on:` block and its cron schedule, before `jobs:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
