### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,5 +1,8 @@
 name: "Lock Threads"
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "50 1 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/terraform-global-naming/security/code-scanning/40](https://github.com/devops-ia/terraform-global-naming/security/code-scanning/40)

In general, the fix is to explicitly declare a `permissions:` block that narrows the `GITHUB_TOKEN` scope to just what this workflow actually needs. Since the locking and commenting are done via the action using a PAT, the implicit `GITHUB_TOKEN` can typically be restricted to read-only repository contents, or even `permissions: {}` if truly unused. To keep a safe, minimal, and conventional configuration, we can set `contents: read` at the workflow level so it applies to all jobs (there is only one job here). This will override any broader org/repo default permissions.

The best minimal change without altering functionality is to add a root-level `permissions:` section right after the `name` (or before `jobs`), specifying only read access to contents. No imports or additional definitions are needed for YAML workflows. Concretely, in `.github/workflows/lock.yml`, add:

```yaml
permissions:
  contents: read
```

between the `name` and `on` sections (or between `on` and `jobs`; both are valid, but adding it near the top clearly documents workflow-wide permissions). This constrains the `GITHUB_TOKEN` without impacting use of `secrets.PAT_GITHUB`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
