### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   auto-assign:
+    permissions:
+      contents: read
     uses: devops-ia/.github/.github/workflows/auto-assign.yaml@bcf48ba70f79f6f494b1831d1a5b992e474091d8
     with:
       teams: devops-ia


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/terraform-global-naming/security/code-scanning/39](https://github.com/devops-ia/terraform-global-naming/security/code-scanning/39)

In general, to fix this class of problem you add an explicit `permissions` block either at the top level of the workflow (applies to all jobs without their own `permissions`) or directly under the specific job. The block should grant only the scopes the workflow actually needs, defaulting everything else to `none` or omitting it. For workflows that mostly read repository data, `contents: read` is a safe minimal baseline.

For this specific workflow, the only job is `auto-assign`, which delegates to a reusable workflow in another repository. The outer workflow itself does not perform any operations; it simply passes inputs and a secret. Therefore, it is safe and appropriate to restrict the `GITHUB_TOKEN` to read-only on repository contents. We’ll add a `permissions` block at the job level under `auto-assign:` with `contents: read`. This will limit the `GITHUB_TOKEN` used in this job while leaving the passed PAT secret unchanged, thus not altering existing functionality of the reusable workflow. The change is confined to `.github/workflows/auto-assign.yml`, inserting the new block immediately under the `auto-assign:` job key with correct indentation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
