### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: Pre-Commit
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/terraform-global-naming/security/code-scanning/8](https://github.com/devops-ia/terraform-global-naming/security/code-scanning/8)

In general, to fix this issue you should explicitly declare a `permissions` block that grants only the minimal permissions the workflow needs. This can be set at the workflow root (applies to all jobs that do not override it) or per job. Since all jobs here only need to read repository contents for checkout and analysis, the minimal appropriate permission is `contents: read`.

The best fix without changing existing functionality is to add a top-level `permissions` block to `.github/workflows/pre-commit.yml` directly under the `name:` (or before `jobs:`). This way, all jobs (`collectInputs`, `preCommitMinVersions`, `preCommitMaxVersion`) inherit `contents: read`, restricting the GITHUB_TOKEN while avoiding duplication. No steps in the provided snippet require writing to the repo, issues, or PRs, and the workflow is only triggered on `pull_request`, so `contents: read` is sufficient and safe.

Concretely:
- Edit `.github/workflows/pre-commit.yml`.
- After line 1 (`name: Pre-Commit`) insert:
  ```yaml
  permissions:
    contents: read
  ```
- Leave the rest of the workflow unchanged. No imports or additional definitions are needed, as this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
