### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
       - "**/*.tf"
       - ".github/workflows/release.yml"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/terraform-global-naming/security/code-scanning/7](https://github.com/devops-ia/terraform-global-naming/security/code-scanning/7)

In general, the problem is fixed by adding an explicit `permissions` block to the workflow (or to the individual job) that grants only the minimal permissions required. For a release workflow using `semantic-release`, write access to repository contents (tags, releases, changelog commits) is typically needed, and sometimes to issues or pull requests. Since this workflow already uses a PAT for `GITHUB_TOKEN`, adding a `permissions` block will only constrain the automatically provided `GITHUB_TOKEN`, not the PAT itself, and will not change current behavior of the action.

The single best minimal change here is to add a top‑level `permissions` block after the `on:` section that grants `contents: write`. This keeps the fix simple, applies to all jobs (we only have `release`), and follows GitHub’s recommended pattern. If you know the release process also needs to update or comment on issues/PRs, you could further refine permissions (for example, adding `issues: write` and/or `pull-requests: write`), but based solely on the snippet shown we should not assume that. Concretely, in `.github/workflows/release.yml`, insert:

```yaml
permissions:
  contents: write
```

between the trigger definition (`on:` block) and the `jobs:` block. No imports or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
