### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: Pre-Commit
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/terraform-global-naming/security/code-scanning/5](https://github.com/devops-ia/terraform-global-naming/security/code-scanning/5)

In general, the problem is fixed by explicitly declaring a `permissions` block to limit the default GITHUB_TOKEN permissions to the minimum required. This can be done at the workflow root (applies to all jobs) or per job. Since all jobs here only need to read repository contents (for checkout and Terraform/pre‑commit analysis), we can safely set `contents: read` at the workflow level. If future jobs need more permissions, they can override this with their own `permissions` blocks.

The best fix without changing existing functionality is to add a single top‑level `permissions` section right after the `name: Pre-Commit` line. This will apply to `collectInputs`, `preCommitMinVersions`, and `preCommitMaxVersion`, constraining GITHUB_TOKEN to `contents: read` for all jobs, which is sufficient for `actions/checkout` and read‑only analysis. No other lines need to change, and no additional imports or methods are required, since this is just a YAML configuration adjustment.

Concretely:
- Edit `.github/workflows/pre-commit.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between the existing line 1 (`name: Pre-Commit`) and line 3 (`on:`). This documents and enforces minimal permissions across the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
