### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,8 @@
 name: Pre-Commit
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/terraform-global-naming/security/code-scanning/3](https://github.com/devops-ia/terraform-global-naming/security/code-scanning/3)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal required scopes for this workflow. Since this workflow only checks out code and runs Terraform / pre-commit tooling, it should need only read access to repository contents. The simplest least-privilege fix is to define `permissions: contents: read` at the top (root) of the workflow so that it applies to all jobs that do not override it.

Concretely, in `.github/workflows/pre-commit.yml`, add a root-level `permissions:` section just after the `name: Pre-Commit` line (before `on:`). The block should be:

```yaml
permissions:
  contents: read
```

No other functionality or steps need to change. No additional imports, methods, or definitions are required, because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
