### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   auto-assign:
+    permissions:
+      contents: read
     uses: devops-ia/.github/.github/workflows/auto-assign.yaml@bcf48ba70f79f6f494b1831d1a5b992e474091d8
     with:
       teams: devops-ia

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,5 +1,8 @@
 name: "Lock Threads"
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "50 1 * * *"

--- a/.github/workflows/pr-tittle.yml
+++ b/.github/workflows/pr-tittle.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: Pre-Commit
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,6 +2,9 @@ name: Pre-Commit
 permissions:
   contents: read
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
       - "**/*.tf"
       - ".github/workflows/release.yml"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release

--- a/.github/workflows/stale-actions.yml
+++ b/.github/workflows/stale-actions.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/terraform-global-naming/security/code-scanning/1](https://github.com/devops-ia/terraform-global-naming/security/code-scanning/1)

In general, the fix is to declare an explicit `permissions:` block with least-privilege scopes either at the root of the workflow (to apply to all jobs) or within the `main` job definition. Since this workflow only validates PR titles and uses a third-party action that reads PR data, read-only permissions are sufficient for `GITHUB_TOKEN`. We do not need write permissions.

The best minimal fix without changing existing functionality is to add a `permissions:` block at the top workflow level, right under the `on:` block (or before `jobs:`), with read-only scopes. A safe and clear choice is:

```yaml
permissions:
  contents: read
  pull-requests: read
```

This will apply to all jobs (currently just `main`) and ensure that the automatically provided `GITHUB_TOKEN` cannot perform write operations, while still allowing the workflow to read repository contents and pull request metadata. No imports or additional methods are needed because this is purely a YAML configuration change inside `.github/workflows/pr-tittle.yml`.

Specifically:
- Edit `.github/workflows/pr-tittle.yml`.
- Insert the `permissions:` block after the `on:` section (after line 8 and before line 10 in the provided snippet).
- Leave the existing `GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}` usage unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
